### PR TITLE
[FIX] edi: Make read/write use bytes-str

### DIFF
--- a/addons/edi/models/edi_connection_sftp.py
+++ b/addons/edi/models/edi_connection_sftp.py
@@ -84,7 +84,7 @@ class EdiConnectionSFTP(models.AbstractModel):
             filepath = os.path.join(path.path, dirent.filename)
             _logger.info("%s receiving %s", transfer.gateway_id.name,
                          filepath)
-            data = conn.file(filepath, mode='r').read()
+            data = conn.file(filepath, mode='rb').read()
 
             # Create new attachment for received file
             attachment = Attachment.create({
@@ -146,7 +146,7 @@ class EdiConnectionSFTP(models.AbstractModel):
             filepath = os.path.join(path.path, attachment.datas_fname)
             _logger.info("%s sending %s", transfer.gateway_id.name, filepath)
             data = base64.b64decode(attachment.datas)
-            conn.file(temppath, mode='w').write(data)
+            conn.file(temppath, mode='wb').write(data)
 
             # Rename temporary file
             conn.rename(temppath, filepath)


### PR DESCRIPTION
Inside send_inputs and receive_inputs currently fail due to a byte-str/str
mismatch.

So just read and write as byte-str we do not have this issue.