### PR TITLE
[IMP] edi: Define a "safety catch" option

### DIFF
--- a/addons/edi/views/edi_gateway_views.xml
+++ b/addons/edi/views/edi_gateway_views.xml
@@ -86,6 +86,7 @@
 	      <group name="conn" string="Connection">
 		<field name="model_id"/>
 		<field name="server"/>
+		<field name="safety"/>
 	      </group>
 	      <group name="history" string="History">
 		<field name="project_id"/>


### PR DESCRIPTION
Define an optional "safety catch" for an EDI gateway.  If present,
this specifies a configuration file option: this configuration file
option must be present and have a truthy value in order for the
gateway to be allowed to initiate connections.

The "test connection" button is deliberately excluded from this check,
since it is plausible that a user may want to test that the
configuration for a gateway is correct prior to enabling the gateway
for production use.

Originally-implemented-by: Charlie Wheeler-Robinson <crwr@pigotts.org.uk>
Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>