### PR TITLE
[IMP] edi_stock: Change edi.pick.request.record to use a synchronizer

### DIFF
--- a/addons/edi_stock/models/edi_pick_request_record.py
+++ b/addons/edi_stock/models/edi_pick_request_record.py
@@ -1,8 +1,6 @@
 """EDI stock transfer request records"""
 
 from odoo import api, fields, models
-from odoo.tools.translate import _
-from odoo.exceptions import UserError
 
 
 class EdiPickRequestRecord(models.Model):
@@ -18,12 +16,16 @@ class EdiPickRequestRecord(models.Model):
     define a priority level which could be converted to a stock
     transfer due date based on some hardcoded business rules.
 
-    Derived models should implement :meth:`~.pick_values`.
+    Derived models should implement :meth:`~.target_values`.
     """
 
     _name = 'edi.pick.request.record'
-    _inherit = 'edi.record'
+    _inherit = 'edi.record.sync'
     _description = "Stock Transfer Request"
+
+    _edi_sync_target = 'pick_id'
+    _edi_sync_via = 'origin'
+    _edi_sync_domain = [('state', '!=', 'cancel')]
 
     pick_type_id = fields.Many2one('stock.picking.type', string="Type",
                                    required=True, readonly=True, index=True)
@@ -33,45 +35,16 @@ class EdiPickRequestRecord(models.Model):
     _sql_constraints = [('doc_name_uniq', 'unique (doc_id, name)',
                          "Each name may appear at most once per document")]
 
-    @api.multi
-    def get_not_started_picking(self):
-        """ Gets a picking with origin equal to self.name and
-            validates that the picking is not started
-        """
-        self.ensure_one()
-        Picking = self.env['stock.picking']
-        picking = Picking.search([
-            ('origin', '=', self.name),
-            ('picking_type_id', '=', self.pick_type_id.id),
-            ('state', 'not in', ['done', 'cancel'])
-        ])
-        if picking.mapped('move_line_ids').filtered(lambda ml: ml.qty_done > 0):
-            raise UserError(
-                _('Picking %s already started.') %
-                picking.mapped('origin'))
-
-        return picking
-
-    @api.multi
-    def pick_values(self):
+    @api.model
+    def target_values(self, record_vals):
         """Construct ``stock.picking`` value dictionary"""
-        self.ensure_one()
-        pick_type = self.pick_type_id
-        return {
-            'origin': self.name,
+        pick_vals = super().target_values(record_vals)
+        PickingType = self.env['stock.picking.type']
+        pick_type = PickingType.browse(record_vals['pick_type_id'])
+        pick_vals.update({
+            'origin': record_vals['name'],
             'picking_type_id': pick_type.id,
             'location_id': pick_type.default_location_src_id.id,
             'location_dest_id': pick_type.default_location_dest_id.id,
-        }
-
-    @api.multi
-    def execute(self):
-        """Execute records"""
-        super().execute()
-        Picking = self.env['stock.picking']
-        for rec in self:
-            picking = rec.get_not_started_picking()
-            if not picking:
-                pick_vals = rec.pick_values()
-                picking = Picking.create(pick_vals)
-            rec.pick_id = picking
+        })
+        return pick_vals

--- a/addons/edi_stock/tests/test_pick_request_tutorial.py
+++ b/addons/edi_stock/tests/test_pick_request_tutorial.py
@@ -104,8 +104,7 @@ class TestTutorial(EdiPickCase):
         pick.action_done()
         doc = self.create_tutorial('out02.csv')
         self.assertTrue(doc.action_execute())
-        pick = doc.mapped('pick_request_tutorial_ids.pick_id')
-        moves = pick.move_lines
+        moves = doc.mapped('move_request_tutorial_ids.move_id')
         moves_by_code = {x.product_id.default_code: x for x in moves}
         self.assertEqual(moves_by_code['APPLE'].product_uom_qty, 3)
         self.assertEqual(moves_by_code['BANANA'].product_uom_qty, 5)

--- a/addons/edi_stock/views/edi_move_request_views.xml
+++ b/addons/edi_stock/views/edi_move_request_views.xml
@@ -18,7 +18,7 @@
 	    <group>
 	      <group name="basic">
 		<field name="doc_id"/>
-		<field name="pick_request_id"/>
+		<field name="pick_key"/>
 		<field name="pick_id"/>
 		<field name="tracker_key"/>
 		<field name="tracker_id"/>
@@ -44,7 +44,7 @@
 	<tree string="Stock Move Requests" default_order="doc_id desc, id">
 	  <field name="doc_id"/>
 	  <field name="name"/>
-	  <field name="pick_request_id"/>
+	  <field name="pick_key"/>
 	  <field name="pick_id"/>
 	  <field name="tracker_key"/>
 	  <field name="tracker_id"/>
@@ -67,7 +67,7 @@
 		 filter_domain="['|',('name','ilike',self),
 				     ('product_key','ilike',self)]"/>
 	  <field name="doc_id"/>
-	  <field name="pick_request_id"/>
+	  <field name="pick_key"/>
 	  <field name="pick_id"/>
 	  <field name="tracker_key"/>
 	  <field name="tracker_id"/>

--- a/addons/edi_stock/views/edi_pick_request_tutorial_views.xml
+++ b/addons/edi_stock/views/edi_pick_request_tutorial_views.xml
@@ -105,7 +105,7 @@
 	    <field name="move_request_tutorial_ids" readonly="1">
 	      <tree>
 		<field name="name"/>
-		<field name="pick_request_id"/>
+		<field name="pick_key"/>
 		<field name="pick_id"/>
 		<field name="tracker_id"/>
 		<field name="move_id"/>


### PR DESCRIPTION
Use a synchronizer approach to handling edi.pick.request.record.  This
allows us to remove the explicit foreign key relationship between
edi.move.request.record and edi.pick.request.record (which causes
additional work when subclassing either of these classes), and allows
for move request records to refer to existing stock.picking records
without requiring the existence of a corresponding pick request
record.

Default to filtering out cancelled stock.picking records, on the basis
that an EDI document for an already-cancelled picking probably
represents a situation in which the operation has decided to cancel
the picking due to a fault in the original EDI document, and is now
attempting to recreate the picking after fixing the problem with the
EDI document.  Subclasses (such as the pick request tutorial) may
choose to modify this filtering policy.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>