### PR TITLE
[FIX] edi: Defer document creation until autodetection order is known

### DIFF
--- a/addons/edi/tests/test_autocreate.py
+++ b/addons/edi/tests/test_autocreate.py
@@ -41,6 +41,7 @@ class TestAutocreate(EdiCase):
 
     def test02_order(self):
         """Order of autocreated documents"""
+        EdiDocument = self.env['edi.document']
         docs = self.autocreate('dummy.txt', 'res.users.csv', 'hello_world.txt')
         self.assertEqual(len(docs), 2)
         self.assertEqual(docs[0].input_ids.sorted('id').mapped('datas_fname'),
@@ -53,6 +54,8 @@ class TestAutocreate(EdiCase):
                          ['res.users.csv'])
         self.assertEqual(docs[1].input_ids.sorted('id').mapped('datas_fname'),
                          ['dummy.txt', 'hello_world.txt'])
+        self.assertEqual(list(docs),
+                         list(EdiDocument.search([('id', 'in', docs.ids)])))
 
     def test03_wizard_create(self):
         """Autocreate via wizard"""


### PR DESCRIPTION
Sorting the autocreated document recordset is insufficient since this
ordering will be lost when the recordset is stored in a Many2many
field.

Fix by separating document creation from document type detection, so
that the documents will be created in the intended order and hence
maintained in this order upon subsequent retrieval from the database.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>