### PR TITLE
[IMP] edi: Allow groupby() to use a recordset as the sorting key

### DIFF
--- a/addons/edi/models/models.py
+++ b/addons/edi/models/models.py
@@ -28,14 +28,12 @@ def batched(self, size=models.PREFETCH_MAX):
     return tools.ranged(self.sliced(size=size))
 
 @add_if_not_exists(models.BaseModel)
-def groupby(self, key=None, sort=True):
+def groupby(self, key, sort=True):
     """Return the recordset ``self`` grouped by ``key``"""
     recs = self
-    if sort:
-        recs = recs.sorted(key=key)
-    if key is None:
-        return recs
     if isinstance(key, str):
         key = itemgetter(key)
+    if sort:
+        recs = recs.sorted(key=key)
     return ((k, self.browse(x.id for x in v))
             for k, v in itertools.groupby(recs, key=key))

--- a/addons/edi_sale/models/edi_sale_report_tutorial.py
+++ b/addons/edi_sale/models/edi_sale_report_tutorial.py
@@ -101,9 +101,9 @@ class EdiSaleReportTutorialDocument(models.AbstractModel):
         """
         return (
             product_lines.with_context(default_name='%04d' % index)
-            for _order_id, order_lines in lines.groupby(lambda x: x.order_id.id)
-            for index, (_product_id, product_lines) in enumerate(
-                order_lines.groupby(lambda x: x.product_id.id)
+            for _order, order_lines in lines.groupby(lambda x: x.order_id)
+            for index, (_product, product_lines) in enumerate(
+                order_lines.groupby(lambda x: x.product_id)
             )
         )
 

--- a/addons/edi_stock/models/edi_move_request_record.py
+++ b/addons/edi_stock/models/edi_move_request_record.py
@@ -142,8 +142,8 @@ class EdiMoveRequestRecord(models.Model):
 
         # Associate moves to pickings.  Do this as a bulk operation to
         # avoid triggering updates on the picking for each new move.
-        for pick_id, recs in self.groupby(lambda x: x.pick_id.id):
-            recs.mapped('move_id').write({'picking_id': pick_id})
+        for pick, recs in self.groupby(lambda x: x.pick_id):
+            recs.mapped('move_id').write({'picking_id': pick.id})
 
         # Cancel moves in bulk
         cancel._action_cancel()

--- a/addons/edi_stock/models/edi_pick_report_tutorial.py
+++ b/addons/edi_stock/models/edi_pick_report_tutorial.py
@@ -82,9 +82,9 @@ class EdiPickReportTutorialDocument(models.AbstractModel):
         """
         return (
             product_moves.with_context(default_name='%04d' % index)
-            for _pick_id, pick_moves in moves.groupby(lambda x: x.picking_id.id)
-            for index, (_product_id, product_moves) in enumerate(
-                pick_moves.groupby(lambda x: x.product_id.id)
+            for _pick, pick_moves in moves.groupby(lambda x: x.picking_id)
+            for index, (_product, product_moves) in enumerate(
+                pick_moves.groupby(lambda x: x.product_id)
             )
         )
 


### PR DESCRIPTION
Using groupby() with a key that produces a recordset (e.g. a Many2one
field name) will currently result in undefined behaviour since
singleton recordset objects cannot be compared for ordered inequality
using the standard comparison operators.

The standard point-of-use workaround is to use a key that produces a
recordset ID instead of the recordset object itself.  This results in
cumbersome code that must perform an explicit browse() to reconstruct
the desired singleton recordset.

Support the use of a recordset as the sorting key by checking for a
key that produces a recordset object and modifying the sort key to
automatically use the (assumed singleton) recordset's ID.  The
grouping key is left unmodified, since singleton recordsets may safely
be compared for equality using the standard comparison operators.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>