### PR TITLE
[IMP] edi: Define base views for all core record types

### DIFF
--- a/addons/edi/views/edi_partner_tutorial_views.xml
+++ b/addons/edi/views/edi_partner_tutorial_views.xml
@@ -51,7 +51,7 @@
       <field name="model">edi.document</field>
       <field name="inherit_id" ref="edi.document_form"/>
       <field name="arch" type="xml">
-	<xpath expr="//notebook[@name='records']" position="inside">
+	<xpath expr="//page[@name='partner']" position="after">
 	  <page name="partner_tutorial" string="Partners"
 		attrs="{'invisible':['!',('rec_type_names','ilike',
 		       '/edi.partner.tutorial.record/')]}">

--- a/addons/edi_sale/models/edi_sale_line_request_record.py
+++ b/addons/edi_sale/models/edi_sale_line_request_record.py
@@ -8,6 +8,17 @@ from odoo.tools.translate import _
 _logger = logging.getLogger(__name__)
 
 
+class EdiDocument(models.Model):
+    """Extend ``edi.document`` to include sale line request records"""
+
+    _inherit = 'edi.document'
+
+    sale_line_request_ids = fields.One2many(
+        'edi.sale.line.request.record', 'doc_id',
+        string="Sale Line Requests",
+    )
+
+
 class EdiSaleLineRequestRecord(models.Model):
     """EDI sale line request record
 

--- a/addons/edi_sale/models/edi_sale_request_record.py
+++ b/addons/edi_sale/models/edi_sale_request_record.py
@@ -3,6 +3,25 @@
 from odoo import api, fields, models
 
 
+class EdiDocument(models.Model):
+    """Extend ``edi.document`` to include sale order request records"""
+
+    _inherit = 'edi.document'
+
+    sale_request_ids = fields.One2many(
+        'edi.sale.request.record', 'doc_id',
+        string="Sale Requests",
+    )
+
+    @api.multi
+    @api.depends('sale_request_ids',
+                 'sale_request_ids.sale_id')
+    def _compute_sale_ids(self):
+        super()._compute_sale_ids()
+        for doc in self:
+            doc.sale_ids += doc.mapped('sale_request_ids.sale_id')
+
+
 class EdiSaleRequestRecord(models.Model):
     """EDI sale order request record
 

--- a/addons/edi_sale/views/edi_sale_report_tutorial_views.xml
+++ b/addons/edi_sale/views/edi_sale_report_tutorial_views.xml
@@ -90,7 +90,7 @@
       <field name="model">edi.document</field>
       <field name="inherit_id" ref="edi.document_form"/>
       <field name="arch" type="xml">
-	<xpath expr="//notebook[@name='records']" position="inside">
+	<xpath expr="//page[@name='sale_report']" position="after">
 	  <page name="sale_report_tutorial" string="Sales"
 		attrs="{'invisible':['!',('rec_type_names','ilike',
 		       '/edi.sale.report.tutorial.record/')]}">

--- a/addons/edi_sale/views/edi_sale_request_tutorial_views.xml
+++ b/addons/edi_sale/views/edi_sale_request_tutorial_views.xml
@@ -84,7 +84,7 @@
       <field name="model">edi.document</field>
       <field name="inherit_id" ref="edi.document_form"/>
       <field name="arch" type="xml">
-	<xpath expr="//notebook[@name='records']" position="inside">
+	<xpath expr="//page[@name='sale_request']" position="after">
 	  <page name="sale_request_tutorial" string="Sales"
 		attrs="{'invisible':['!',('rec_type_names','ilike',
 		       '/edi.sale.request.tutorial.record/')]}">

--- a/addons/edi_sale/views/edi_sale_request_views.xml
+++ b/addons/edi_sale/views/edi_sale_request_views.xml
@@ -75,5 +75,27 @@
       <field name="context">{'create': False}</field>
     </record>
 
+    <!-- EDI sale request records field -->
+    <record id="sale_request_document_form" model="ir.ui.view">
+      <field name="name">edi.sale.request.document.form</field>
+      <field name="model">edi.document</field>
+      <field name="inherit_id" ref="edi.document_form"/>
+      <field name="arch" type="xml">
+	<xpath expr="//notebook[@name='records']" position="inside">
+	  <page name="sale_request" string="Sales"
+		attrs="{'invisible':['!',('rec_type_names','ilike',
+		       '/edi.sale.request.record/')]}">
+	    <field name="sale_request_ids" readonly="1">
+	      <tree>
+		<field name="name"/>
+		<field name="customer_key"/>
+		<field name="customer_id"/>
+	      </tree>
+	    </field>
+	  </page>
+	</xpath>
+      </field>
+    </record>
+
   </data>
 </odoo>

--- a/addons/edi_stock/models/edi_move_report_record.py
+++ b/addons/edi_stock/models/edi_move_report_record.py
@@ -4,6 +4,17 @@ from odoo import api, fields, models
 from odoo.addons import decimal_precision as dp
 
 
+class EdiDocument(models.Model):
+    """Extend ``edi.document`` to include stock move report records"""
+
+    _inherit = 'edi.document'
+
+    move_report_ids = fields.One2many(
+        'edi.move.report.record', 'doc_id',
+        string="Stock Moves",
+    )
+
+
 class EdiMoveReportRecord(models.Model):
     """EDI stock move report record
 

--- a/addons/edi_stock/models/edi_move_request_record.py
+++ b/addons/edi_stock/models/edi_move_request_record.py
@@ -9,6 +9,17 @@ from odoo.exceptions import UserError
 _logger = logging.getLogger(__name__)
 
 
+class EdiDocument(models.Model):
+    """Extend ``edi.document`` to include stock move request records"""
+
+    _inherit = 'edi.document'
+
+    move_request_ids = fields.One2many(
+        'edi.move.request.record', 'doc_id',
+        string="Stock Moves",
+    )
+
+
 class EdiMoveRequestRecord(models.Model):
     """EDI stock move request record
 

--- a/addons/edi_stock/models/edi_pick_report_record.py
+++ b/addons/edi_stock/models/edi_pick_report_record.py
@@ -3,6 +3,17 @@
 from odoo import api, fields, models
 
 
+class EdiDocument(models.Model):
+    """Extend ``edi.document`` to include stock transfer report records"""
+
+    _inherit = 'edi.document'
+
+    pick_report_ids = fields.One2many(
+        'edi.pick.report.record', 'doc_id',
+        string="Stock Transfer Reports",
+    )
+
+
 class EdiPickReportRecord(models.Model):
     """EDI stock transfer report record
 

--- a/addons/edi_stock/models/edi_pick_request_record.py
+++ b/addons/edi_stock/models/edi_pick_request_record.py
@@ -3,6 +3,25 @@
 from odoo import api, fields, models
 
 
+class EdiDocument(models.Model):
+    """Extend ``edi.document`` to include stock transfer request records"""
+
+    _inherit = 'edi.document'
+
+    pick_request_ids = fields.One2many(
+        'edi.pick.request.record', 'doc_id',
+        string="Stock Transfer Requests",
+    )
+
+    @api.multi
+    @api.depends('pick_request_ids',
+                 'pick_request_ids.pick_id')
+    def _compute_pick_ids(self):
+        super()._compute_pick_ids()
+        for doc in self:
+            doc.pick_ids += doc.mapped('pick_request_ids.pick_id')
+
+
 class EdiPickRequestRecord(models.Model):
     """EDI stock transfer request record
 

--- a/addons/edi_stock/views/edi_location_tutorial_views.xml
+++ b/addons/edi_stock/views/edi_location_tutorial_views.xml
@@ -51,7 +51,7 @@
       <field name="model">edi.document</field>
       <field name="inherit_id" ref="edi.document_form"/>
       <field name="arch" type="xml">
-	<xpath expr="//notebook[@name='records']" position="inside">
+	<xpath expr="//page[@name='location']" position="after">
 	  <page name="location_tutorial" string="Locations"
 		attrs="{'invisible':['!',('rec_type_names','ilike',
 		       '/edi.location.tutorial.record/')]}">

--- a/addons/edi_stock/views/edi_move_report_views.xml
+++ b/addons/edi_stock/views/edi_move_report_views.xml
@@ -77,5 +77,28 @@
       <field name="context">{'create': False}</field>
     </record>
 
+    <!-- EDI stock move report records field -->
+    <record id="move_report_document_form" model="ir.ui.view">
+      <field name="name">edi.move.report.document.form</field>
+      <field name="model">edi.document</field>
+      <field name="inherit_id" ref="edi.document_form"/>
+      <field name="arch" type="xml">
+	<xpath expr="//notebook[@name='records']" position="inside">
+	  <page name="move_report" string="Stock Moves"
+		attrs="{'invisible':['!',('rec_type_names','ilike',
+		       '/edi.move.report.record/')]}">
+	    <field name="move_report_ids" readonly="1">
+	      <tree>
+		<field name="name"/>
+		<field name="move_ids" widget="many2many_tags"/>
+		<field name="product_id"/>
+		<field name="qty"/>
+	      </tree>
+	    </field>
+	  </page>
+	</xpath>
+      </field>
+    </record>
+
   </data>
 </odoo>

--- a/addons/edi_stock/views/edi_move_request_views.xml
+++ b/addons/edi_stock/views/edi_move_request_views.xml
@@ -96,5 +96,33 @@
       <field name="context">{'create': False}</field>
     </record>
 
+    <!-- EDI stock move request records field -->
+    <record id="move_request_document_form" model="ir.ui.view">
+      <field name="name">edi.move.request.document.form</field>
+      <field name="model">edi.document</field>
+      <field name="inherit_id" ref="edi.document_form"/>
+      <field name="arch" type="xml">
+	<xpath expr="//notebook[@name='records']" position="inside">
+	  <page name="move_request" string="Stock Moves"
+		attrs="{'invisible':['!',('rec_type_names','ilike',
+		       '/edi.move.request.record/')]}">
+	    <field name="move_request_ids" readonly="1">
+	      <tree>
+		 <field name="name"/>
+		 <field name="pick_key"/>
+		 <field name="pick_id"/>
+		 <field name="tracker_key"/>
+		 <field name="tracker_id"/>
+		 <field name="move_id"/>
+		 <field name="product_key"/>
+		 <field name="product_id"/>
+		 <field name="qty"/>
+	      </tree>
+	    </field>
+	  </page>
+	</xpath>
+      </field>
+    </record>
+
   </data>
 </odoo>

--- a/addons/edi_stock/views/edi_orderpoint_tutorial_views.xml
+++ b/addons/edi_stock/views/edi_orderpoint_tutorial_views.xml
@@ -51,7 +51,7 @@
       <field name="model">edi.document</field>
       <field name="inherit_id" ref="edi.document_form"/>
       <field name="arch" type="xml">
-	<xpath expr="//notebook[@name='records']" position="inside">
+	<xpath expr="//page[@name='orderpoint']" position="after">
 	  <page name="orderpoint_tutorial" string="Minimum Inventory Rules"
 		attrs="{'invisible':['!',('rec_type_names','ilike',
 		       '/edi.orderpoint.tutorial.record/')]}">

--- a/addons/edi_stock/views/edi_pick_report_tutorial_views.xml
+++ b/addons/edi_stock/views/edi_pick_report_tutorial_views.xml
@@ -86,7 +86,7 @@
       <field name="model">edi.document</field>
       <field name="inherit_id" ref="edi.document_form"/>
       <field name="arch" type="xml">
-	<xpath expr="//notebook[@name='records']" position="inside">
+	<xpath expr="//page[@name='pick_report']" position="after">
 	  <page name="pick_report_tutorial" string="Stock Transfers"
 		attrs="{'invisible':['!',('rec_type_names','ilike',
 		       '/edi.pick.report.tutorial.record/')]}">
@@ -97,6 +97,8 @@
 	      </tree>
 	    </field>
 	  </page>
+	</xpath>
+	<xpath expr="//page[@name='move_report']" position="after">
 	  <page name="move_report_tutorial" string="Stock Moves"
 		attrs="{'invisible':['!',('rec_type_names','ilike',
 		       '/edi.move.report.tutorial.record/')]}">

--- a/addons/edi_stock/views/edi_pick_report_views.xml
+++ b/addons/edi_stock/views/edi_pick_report_views.xml
@@ -69,5 +69,26 @@
       <field name="context">{'create': False}</field>
     </record>
 
+    <!-- EDI stock transfer report records field -->
+    <record id="pick_report_document_form" model="ir.ui.view">
+      <field name="name">edi.pick.report.document.form</field>
+      <field name="model">edi.document</field>
+      <field name="inherit_id" ref="edi.document_form"/>
+      <field name="arch" type="xml">
+	<xpath expr="//notebook[@name='records']" position="inside">
+	  <page name="pick_report" string="Stock Transfers"
+		attrs="{'invisible':['!',('rec_type_names','ilike',
+		       '/edi.pick.report.record/')]}">
+	    <field name="pick_report_ids" readonly="1">
+	      <tree>
+		<field name="name"/>
+		<field name="pick_id"/>
+	      </tree>
+	    </field>
+	  </page>
+	</xpath>
+      </field>
+    </record>
+
   </data>
 </odoo>

--- a/addons/edi_stock/views/edi_pick_request_tutorial_views.xml
+++ b/addons/edi_stock/views/edi_pick_request_tutorial_views.xml
@@ -91,7 +91,7 @@
       <field name="model">edi.document</field>
       <field name="inherit_id" ref="edi.document_form"/>
       <field name="arch" type="xml">
-	<xpath expr="//notebook[@name='records']" position="inside">
+	<xpath expr="//page[@name='pick_request']" position="after">
 	  <page name="pick_request_tutorial" string="Stock Transfers"
 		attrs="{'invisible':['!',('rec_type_names','ilike',
 		       '/edi.pick.request.tutorial.record/')]}">
@@ -103,6 +103,8 @@
 	      </tree>
 	    </field>
 	  </page>
+	</xpath>
+	<xpath expr="//page[@name='move_request']" position="after">
 	  <page name="move_request_tutorial" string="Stock Moves"
 		attrs="{'invisible':['!',('rec_type_names','ilike',
 		       '/edi.move.request.tutorial.record/')]}">

--- a/addons/edi_stock/views/edi_pick_request_views.xml
+++ b/addons/edi_stock/views/edi_pick_request_views.xml
@@ -74,5 +74,27 @@
       <field name="context">{'create': False}</field>
     </record>
 
+    <!-- EDI stock transfer request records field -->
+    <record id="pick_request_document_form" model="ir.ui.view">
+      <field name="name">edi.pick.request.document.form</field>
+      <field name="model">edi.document</field>
+      <field name="inherit_id" ref="edi.document_form"/>
+      <field name="arch" type="xml">
+	<xpath expr="//notebook[@name='records']" position="inside">
+	  <page name="pick_request" string="Stock Transfers"
+		attrs="{'invisible':['!',('rec_type_names','ilike',
+		       '/edi.pick.request.record/')]}">
+	    <field name="pick_request_ids" readonly="1">
+	      <tree>
+		<field name="name"/>
+		<field name="pick_type_id"/>
+		<field name="pick_id"/>
+	      </tree>
+	    </field>
+	  </page>
+	</xpath>
+      </field>
+    </record>
+
   </data>
 </odoo>

--- a/addons/edi_stock/views/edi_quant_report_tutorial_views.xml
+++ b/addons/edi_stock/views/edi_quant_report_tutorial_views.xml
@@ -47,7 +47,7 @@
       <field name="model">edi.document</field>
       <field name="inherit_id" ref="edi.document_form"/>
       <field name="arch" type="xml">
-	<xpath expr="//notebook[@name='records']" position="inside">
+	<xpath expr="//page[@name='quant_report']" position="after">
 	  <page name="quant_report_tutorial" string="Stock Levels"
 		attrs="{'invisible':['!',('rec_type_names','ilike',
 		       '/edi.quant.report.tutorial.record/')]}">


### PR DESCRIPTION
Allow tutorial views (and other derived-model views) to position
themselves within the records notebook relative to their base model
pages.

Signed-off-by: Sylvie Barlow <sylvie.barlow@unipart.io>