### PR TITLE
[IMP] edi: Forcibly disable message posting during preparation and ex…

### DIFF
--- a/addons/edi/models/__init__.py
+++ b/addons/edi/models/__init__.py
@@ -17,6 +17,7 @@ from . import edi_gateway
 from . import edi_record
 from . import edi_synchronizer
 from . import edi_transfer
+from . import mail_thread
 
 from . import edi_partner_document
 from . import edi_partner_record

--- a/addons/edi/models/mail_thread.py
+++ b/addons/edi/models/mail_thread.py
@@ -1,0 +1,34 @@
+"""Mail threads"""
+
+from odoo import api, models
+
+
+class MailThread(models.AbstractModel):
+    """Mail threads
+
+    Disable mail thread posting whenever the context parameter
+    ``tracking_disable`` is set.
+    """
+
+    _inherit = 'mail.thread'
+
+    @api.multi
+    def message_post(self, *args, **kwargs):
+        """Post message"""
+        if self._context.get('tracking_disable'):
+            return
+        return super().message_post(*args, **kwargs)
+
+    @api.multi
+    def message_post_with_view(self, *args, **kwargs):
+        """Post message using a view"""
+        if self._context.get('tracking_disable'):
+            return
+        return super().message_post_with_view(*args, **kwargs)
+
+    @api.multi
+    def message_post_with_template(self, *args, **kwargs):
+        """Post message using a template"""
+        if self._context.get('tracking_disable'):
+            return
+        return super().message_post_with_template(*args, **kwargs)


### PR DESCRIPTION
…ecution

Several Odoo models post custom change tracking messages without
checking for the tracking_disable context parameter.  This can easily
add 100% to the execution time (especially if the message being posted
is rendered via QWeb).

Work around these performance bugs by skipping all message posting
whenever the tracking_disable context parameter is set.

Note that an EDI document that needs to post a message (e.g. to
annotate a record with a message from an input attachment) must
therefore explicitly set tracking_disable=False within the context.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>