### PR TITLE
[FIX] edi: Rename run_action_edi() to run_action_edi_multi()

### DIFF
--- a/addons/edi/models/edi_gateway.py
+++ b/addons/edi/models/edi_gateway.py
@@ -23,7 +23,7 @@ class ServerActions(models.Model):
                                      index=True, ondelete='cascade')
 
     @api.model
-    def run_action_edi(self, action, eval_context=None):
+    def run_action_edi_multi(self, action, eval_context=None):
         """Run EDI server action"""
         # pylint: disable=unused-argument
         action.edi_gateway_id.action_transfer()


### PR DESCRIPTION
This bypasses active_id/active_ids logic because EDI actions
don't need it.

Signed-off-by: Miquel PS <miquel.palahi.sitges@unipart.io>