### PR TITLE
[FIX] edi: Set edi.document.project_id to read only

### DIFF
--- a/addons/edi/models/edi_document.py
+++ b/addons/edi/models/edi_document.py
@@ -177,7 +177,8 @@ class EdiDocument(models.Model):
                                   compute='_compute_output_count', store=True)
 
     # Issues (i.e. asynchronously reported errors)
-    project_id = fields.Many2one(related='doc_type_id.project_id')
+    project_id = fields.Many2one(related='doc_type_id.project_id',
+                                 readonly=True)
     issue_ids = fields.One2many(inverse_name='edi_doc_id')
 
     # Record type names (solely for use by views)


### PR DESCRIPTION
The field is a related field to doc_type_id.project_id, which
is triggering a write to doc_type_id every time a new document
of that type is created.
This causes issues for users that only have read access rights
to edi.document.type model.

Setting the field as readonly prevents the write to doc_type_id.

Signed-off-by: Miquel PS <miquel.palahi.sitges@unipart.io>