### PR TITLE
[ADD] edi: Add facility for selective query tracing

### DIFF
--- a/addons/edi/models/models.py
+++ b/addons/edi/models/models.py
@@ -52,9 +52,9 @@ def groupby(self, key, sort=True):
             for k, v in itertools.groupby(recs, key=key))
 
 @add_if_not_exists(models.BaseModel)
-def statistics(self):
+def statistics(self, cache=False):
     """Gather profiling statistics for an operation"""
-    return tools.EdiStatistics(self.env)
+    return tools.EdiStatistics(self.env, cache=cache)
 
 @add_if_not_exists(models.BaseModel)
 def trace(self, filter=None, max=None):

--- a/addons/edi/models/models.py
+++ b/addons/edi/models/models.py
@@ -55,3 +55,8 @@ def groupby(self, key, sort=True):
 def statistics(self):
     """Gather profiling statistics for an operation"""
     return tools.EdiStatistics(self.env)
+
+@add_if_not_exists(models.BaseModel)
+def trace(self, filter=None, max=None):
+    """Trace database queries"""
+    return tools.EdiTracer(self.env.cr, filter=filter, max=max)

--- a/addons/edi/tools/__init__.py
+++ b/addons/edi/tools/__init__.py
@@ -4,3 +4,4 @@ from .comparators import Comparator
 from .iterators import batched, ranged, sliced, NoRecordValuesError
 from .sap import sap_idoc_type, SapIDoc
 from .statistics import EdiStatistics
+from .tracing import EdiTracer

--- a/addons/edi/tools/tracing.py
+++ b/addons/edi/tools/tracing.py
@@ -1,0 +1,127 @@
+"""Query tracing"""
+
+from itertools import takewhile
+import logging
+import re
+import traceback
+from odoo import models
+from odoo.sql_db import Cursor
+
+_logger = logging.getLogger(__name__)
+
+
+# Patch base Cursor class to provide "tracing" attribute
+Cursor.tracing = False
+
+
+class EdiTracer(object):
+    """Query tracer
+
+    A query tracer can be used to temporarily wrap the ``execute``
+    method on a database cursor in order to log selected queries.  The
+    logged queries will be shown along with the query parameters and
+    an incremental traceback.
+
+    The incremental traceback will omit any stack frames that are
+    identical between the point of creating the query tracer and the
+    point of executing the query.  This typically produces a traceback
+    showing only the portions of interest.
+
+    The optional ``filter`` argument may be used to limit the queries
+    that are logged.  ``filter`` may be a case-insensitive regular
+    expression string used to match against the query string, an
+    instance of ``BaseModel``, or a callable taking the query string
+    as a single argument.  Any other value for ``filter`` will be
+    treated as a truth value.
+
+    Example useful filter expressions:
+
+        # Trace all INSERTs
+        filter='INSERT'
+
+        # Trace all UPDATEs
+        filter='UPDATE'
+
+        # Trace all queries touching a field named "scheduled_date"
+        filter='scheduled_date'
+
+        # Trace all queries touching the res.partner model table
+        filter='res_partner'
+
+        # Trace all queries touching res.partner (alternative approach)
+        filter=self.env['res.partner']
+
+        # Trace all INSERT queries if there are more than 100 records
+        filter=(len(self) > 100 and 'INSERT')
+
+    The optional ``max`` parameter may be used to limit the total
+    number of queries that are logged.
+
+    The query tracer may either be used as a context manager, in which
+    case query tracing will be stopped automatically.
+
+    The ``stop`` method allows tracing to be stopped for a query
+    tracer that is not used as a context manager.
+
+    """
+
+    def __init__(self, cr, filter=None, max=None):
+        self.cr = cr
+        self.execute = cr.execute
+        if filter is None:
+            self.filter = True
+        elif isinstance(filter, models.BaseModel):
+            self.filter = re.compile('"%s"' % filter._table).search
+        elif isinstance(filter, str):
+            self.filter = re.compile(filter, re.I).search
+        else:
+            self.filter = filter
+        self.max = max
+        self.count = 0
+        self.tb = traceback.extract_stack()
+        self.start()
+
+    def trace(self, query, params=None, log_exceptions=None):
+        """Trace query"""
+
+        # Log any queries matching the filter
+        if not callable(self.filter) or self.filter(query):
+
+            # Count logged queries, if applicable
+            if self.max is not None:
+                self.count += 1
+                if self.count >= self.max:
+                    self.stop()
+
+            # Skip all but the innermost common stack frames
+            full_tb = traceback.extract_stack()[:-1]
+            init_tb = iter(self.tb)
+            common = takewhile(lambda x: x == next(init_tb, None), full_tb)
+            skip = max((len(list(common)) - 1), 0)
+            tb = full_tb[skip:]
+
+            # Log query, parameters, and incremental traceback
+            _logger.info("query: %s : %s\n%s", query, params,
+                         ''.join(traceback.format_list(tb)))
+
+        return self.execute(query, params=params,
+                            log_exceptions=log_exceptions)
+
+    def start(self):
+        """Start tracing queries"""
+        self.count = 0
+        if self.filter:
+            self.cr.execute = self.trace
+            self.cr.tracing = True
+
+    def stop(self):
+        """Stop tracing queries"""
+        self.cr.execute = self.execute
+        self.cr.tracing = False
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, tb):
+        self.stop()

--- a/addons/edi_sale/models/edi_sale_line_request_record.py
+++ b/addons/edi_sale/models/edi_sale_line_request_record.py
@@ -64,9 +64,6 @@ class EdiSaleLineRequestRecord(models.Model):
         """Execute records"""
         super().execute()
         SaleLine = self.env['sale.order.line']
-        Sale = self.env['sale.order']
-        Product = self.env['product.product']
-        Template = self.env['product.template']
 
         # Identify containing EDI document
         doc = self.mapped('doc_id')
@@ -79,11 +76,10 @@ class EdiSaleLineRequestRecord(models.Model):
 
             # Cache related records for this batch to reduce
             # per-record database lookups
-            sales = Sale.browse(batch.mapped('order_id.id'))
+            sales = batch.mapped('order_id')
             sales.mapped('name')
-            products = Product.browse(batch.mapped('product_id.id'))
-            templates = Template.browse(products.mapped('product_tmpl_id.id'))
-            templates.mapped('name')
+            products = batch.mapped('product_id')
+            products.mapped('name')
 
             # Create order lines
             with self.statistics() as stats:

--- a/addons/edi_sale/models/edi_sale_line_request_record.py
+++ b/addons/edi_sale/models/edi_sale_line_request_record.py
@@ -78,6 +78,8 @@ class EdiSaleLineRequestRecord(models.Model):
             # per-record database lookups
             sales = batch.mapped('order_id')
             sales.mapped('name')
+            partners = sales.mapped('partner_id')
+            partners.mapped('name')
             products = batch.mapped('product_id')
             products.mapped('name')
 

--- a/addons/edi_sale/models/edi_sale_line_request_record.py
+++ b/addons/edi_sale/models/edi_sale_line_request_record.py
@@ -54,6 +54,7 @@ class EdiSaleLineRequestRecord(models.Model):
         return {
             'name': self.name,
             'product_id': self.product_id.id,
+            'product_uom': self.product_id.uom_id.id,
             'product_uom_qty': self.qty,
             'order_id': self.order_id.id,
         }

--- a/addons/edi_sale/models/edi_sale_request_document.py
+++ b/addons/edi_sale/models/edi_sale_request_document.py
@@ -102,5 +102,6 @@ class EdiSaleRequestDocument(models.AbstractModel):
                 _logger.info("%s confirming %s", doc.name, sale.name)
                 with self.statistics() as stats:
                     sale.action_confirm()
+                    self.recompute()
                 _logger.info("%s confirmed %s in %.2fs, %d queries", doc.name,
                              sale.name, stats.elapsed, stats.count)


### PR DESCRIPTION
Add the ability to trace database queries arising from a specified
point of use within the code.  Queries are logged along with their
parameter values and the incremental stack trace leading from the
point of use up to the query execution.

For example, to show all queries (including implicit queries such as
default value lookups) arising from creating a single record:

  Partner = self.env['res.partner']
  Partner.trace().create(vals)

To show all queries arising from modifying a field value:

  picking.trace().move_lines.write({'product_qty': 3})

To show only the UPDATE queries:

  picking.trace('UPDATE').move_lines.write({'product_qty': 3})

To show only queries arising from creating the second record in a
batch and that mention a field called "scheduled_date":

  Sale = self.env['sale.order']
  for vals in batch:
      Sale.trace(vals == batch[1] and 'scheduled_date').create(vals)

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>