### PR TITLE
[IMP] edi: Allow for non-automatic gateways

### DIFF
--- a/addons/edi/models/edi_gateway.py
+++ b/addons/edi/models/edi_gateway.py
@@ -114,6 +114,7 @@ class EdiGateway(models.Model):
         connections.
         """,
     )
+    automatic = fields.Boolean(string="Process automatically", default=True)
     resend = fields.Boolean(string="Resend missing files", default=True)
 
     # Authentication
@@ -330,7 +331,11 @@ class EdiGateway(models.Model):
     def do_transfer(self, conn=None):
         """Receive input attachments, process documents, send outputs"""
         self.ensure_one()
-        transfer = self.transfer_ids.create({'gateway_id': self.id})
+        transfer = self.transfer_ids.create({
+            'gateway_id': self.id,
+            'allow_process': self._context.get('default_allow_process',
+                                               self.automatic),
+        })
         self.lock_for_transfer(transfer)
         Model = self.env[self.model_id.model]
         try:

--- a/addons/edi/tests/test_edi_gateway.py
+++ b/addons/edi/tests/test_edi_gateway.py
@@ -304,6 +304,7 @@ class EdiGatewayConnectionCase(EdiGatewayCase):
     @skipUnlessCanReceive
     def test04_transfer_receive(self):
         """Test receiving attachments"""
+        self.gateway.automatic = False
         with self.patch_paths({self.path_receive: ['hello_world.txt']}):
             transfer = self.gateway.with_context({
                 'default_allow_process': False,
@@ -424,6 +425,20 @@ class EdiGatewayConnectionCase(EdiGatewayCase):
             self.assertEqual(len(transfer.input_ids), 1)
             self.assertEqual(len(transfer.output_ids), 0)
             self.assertAttachment(transfer.input_ids, 'hello_world.txt')
+            self.assertEqual(len(transfer.doc_ids), 1)
+            doc = transfer.doc_ids
+            self.assertEqual(doc.doc_type_id, doc_type)
+            self.assertEqual(doc.state, 'done')
+        self.gateway.automatic = False
+        with self.patch_paths({self.path_receive: ['destroy_world.txt']}):
+            transfer = self.gateway.do_transfer()
+            self.assertEqual(len(transfer.input_ids), 1)
+            self.assertEqual(len(transfer.output_ids), 0)
+            self.assertAttachment(transfer.input_ids, 'destroy_world.txt')
+            self.assertEqual(len(transfer.doc_ids), 1)
+            doc = transfer.doc_ids
+            self.assertEqual(doc.doc_type_id, doc_type)
+            self.assertEqual(doc.state, 'draft')
 
     @skipUnlessCanInitiate
     def test09_action_test_fail(self):

--- a/addons/edi/views/edi_gateway_views.xml
+++ b/addons/edi/views/edi_gateway_views.xml
@@ -88,6 +88,7 @@
 		<field name="server"/>
 		<field name="port"/>
 		<field name="safety"/>
+		<field name="automatic"/>
 		<field name="resend"/>
 	      </group>
 	      <group name="history" string="History">


### PR DESCRIPTION
Allow a gateway to be configured to require manual processing of EDI
documents.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>