### PR TITLE
[IMP] edi: Current document activity status available

### DIFF
--- a/addons/edi/models/edi_gateway.py
+++ b/addons/edi/models/edi_gateway.py
@@ -350,10 +350,9 @@ class EdiGateway(models.Model):
                     raise UserError(_("Gateway disabled via configuration "
                                       "option '%s'") % self.safety)
             if conn is not None:
-                with self.env.cr.savepoint():
-                    transfer.do_transfer(conn)
+                transfer.do_transfer(conn)
             else:
-                with Model.connect(self) as auto_conn, self.env.cr.savepoint():
+                with Model.connect(self) as auto_conn:
                     transfer.do_transfer(auto_conn)
         except Exception as err:
             transfer.raise_issue(_("Transfer failed: %s"), err)

--- a/addons/edi/views/edi_document_views.xml
+++ b/addons/edi/views/edi_document_views.xml
@@ -164,6 +164,13 @@
 		  </div>
 		  <div class="col-xs-6">
 		    <span class="pull-right text-right">
+		      <field name="activity"
+		       widget="label_selection"
+		       options="{'classes': {
+		      		'cancel': 'danger',
+		      		'prep': 'danger',
+		      		'exec': 'danger'}}"
+					 attrs="{'invisible': [('activity','=','none')]}"/>
 		      <field name="state"
 			     widget="label_selection"
 			     options="{'classes': {'draft': 'default',


### PR DESCRIPTION
Adding an activity status to edi.document to contain the
current activity (preparing, executing) of the document.

EDI gateway transfers commit explicitly so that each
stage of transfer>prepare>execute are visible, a
rollback will only occur for a subsection of this
transcation - a failed execution will now  leave a
prepared document that can be viewed in the UI.