### PR TITLE
[FIX] edi_stock: Add conecept of target not yet know for edi relates …

### DIFF
--- a/addons/edi/models/edi_record.py
+++ b/addons/edi/models/edi_record.py
@@ -217,7 +217,7 @@ class EdiRecord(models.AbstractModel):
             # Add target values where known
             for vals in missing:
                 target = targets_by_key.get(vals[rel.key])
-                vals[rel.target] = target.id if target else False
+                vals[rel.target] = target.id if target else models.NewId()
 
     @api.model
     def add_edi_defaults(self, target, vlist):

--- a/addons/edi/tests/files/update_untitled.csv
+++ b/addons/edi/tests/files/update_untitled.csv
@@ -1,0 +1,1 @@
+U,Dm,Untitled,untitled@example.com

--- a/addons/edi/tests/test_partner_tutorial.py
+++ b/addons/edi/tests/test_partner_tutorial.py
@@ -52,3 +52,20 @@ class TestPartnerTutorial(EdiCase):
         self.assertEqual(len(partners), 1)
         self.assertEqual(partners.ref, 'E')
         self.assertEqual(partners.email, 'eve@example.com')
+
+    def test03_correction(self):
+        """Document and subsequent correction document"""
+        Title = self.env['res.partner.title']
+        doc1 = self.create_tutorial('friends.csv')
+        self.assertTrue(doc1.action_execute())
+        partners = doc1.mapped('partner_tutorial_ids.partner_id')
+        self.assertEqual(len(partners), 4)
+        doc2 = self.create_tutorial('update_untitled.csv')
+        self.assertTrue(doc2.action_prepare())
+        dame_title = Title.create({'name': 'Dame', 'shortcut': 'Dm'})
+        self.assertTrue(doc2.action_execute())
+        partners = doc2.mapped('partner_tutorial_ids.partner_id')
+        self.assertEqual(len(partners), 1)
+        self.assertEqual(partners.ref, 'U')
+        self.assertEqual(partners.email, 'untitled@example.com')
+        self.assertTrue(partners.title, dame_title)

--- a/addons/edi/tools/comparators.py
+++ b/addons/edi/tools/comparators.py
@@ -1,7 +1,7 @@
 """Comparator helpers for EDI"""
 
 from collections import UserDict
-from odoo import fields
+from odoo import fields, models
 from odoo.tools import float_compare
 
 
@@ -29,7 +29,10 @@ class Comparator(UserDict):
     def comparator(self, field):
         """Construct comparator function"""
         if isinstance(field, fields.Many2one):
-            return lambda x, y: (not x and not y) or (x.id == y)
+            return lambda x, y: (
+                (not x and not y and not isinstance(y, models.NewId))
+                or (x.id == y)
+            )
         elif isinstance(field, fields.Float) and field.digits:
             (_precision, scale) = field.digits
             return lambda x, y: float_compare(x, y, precision_digits=scale) == 0


### PR DESCRIPTION
…field

A syncronizer will not recognise a change in an edi related field if that
field is not set beforehand. By marking it with target "not yet
known" signals to the syncronizer that this value will be different after
execution and therefore should not be elided.

User-story: story/4349
Signed-off-by: Michele Costa <michele.costa@unipart.io>