### PR TITLE
[FIX] edi: Make an assertion failure in tearDown() method not cause m…

### DIFF
--- a/addons/edi/tests/test_edi_gateway.py
+++ b/addons/edi/tests/test_edi_gateway.py
@@ -177,9 +177,10 @@ class EdiGatewayCase(EdiCase):
 
     def tearDown(self):
         # Check for exceptions that have been caught and converted to issues
-        self.assertEqual(len(self.gateway.issue_ids), 0)
+        num_issues = len(self.gateway.issue_ids)
         super().tearDown()
         del self.ssh_server
+        self.assertEqual(num_issues, 0)
 
 
 class EdiGatewayCommonCase(EdiGatewayCase):


### PR DESCRIPTION
…ore failures.

Gateway asserts that there are no non-cleared failures in its tearDown() method.
If an assert failed, it used to exit the tearDown method causing a
savepoint not to be rollbacked, causing every other test in the suite to
fail. This commit fixes this issue.

Story: 4392