### PR TITLE
FIX: edi_sale: add "stock" dependency

### DIFF
--- a/addons/edi_sale/__manifest__.py
+++ b/addons/edi_sale/__manifest__.py
@@ -13,7 +13,7 @@ Key Features
 * Report completed sales order to external EDI sources
     """,
     'version': '0.1',
-    'depends': ['edi', 'sale'],
+    'depends': ['edi', 'sale', 'stock'],
     'author': "Michael Brown <mbrown@fensystems.co.uk>",
     'category': "Extra Tools",
     'data': [


### PR DESCRIPTION
edi_sale uses product.template.type field, which is defined in the stock module. Not having it in dependencies leads to an error when initialising the db.

Task: 4504