### PR TITLE
[ADD] edi: Added test for collision of NewIds in partner records

### DIFF
--- a/addons/edi/tests/files/repeated_friend.csv
+++ b/addons/edi/tests/files/repeated_friend.csv
@@ -1,0 +1,5 @@
+A,Miss,Alice,alice@example.com
+B,Mr,Bob,bob@example.com
+B,Mr,Bob,bob@example.com
+E,Ms,Eve,eve@example.com
+U,,Untitled,untitled@example.com

--- a/addons/edi/tests/test_partner_tutorial.py
+++ b/addons/edi/tests/test_partner_tutorial.py
@@ -69,3 +69,15 @@ class TestPartnerTutorial(EdiCase):
         self.assertEqual(partners.ref, 'U')
         self.assertEqual(partners.email, 'untitled@example.com')
         self.assertTrue(partners.title, dame_title)
+
+    def test04_doppelganger(self):
+        """Test that if a partner is repeated it is correctly ingested"""
+        doc = self.create_tutorial('repeated_friend.csv')
+        self.assertTrue(doc.action_execute())
+        partners = doc.mapped('partner_tutorial_ids.partner_id')
+        self.assertEqual(len(partners), 4)
+        partners_by_ref = {x.ref: x for x in partners}
+        self.assertEqual(partners_by_ref['A'].name, 'Alice')
+        self.assertEqual(partners_by_ref['B'].email, 'bob@example.com')
+        self.assertEqual(partners_by_ref['E'].title.name, 'Ms')
+        self.assertFalse(partners_by_ref['U'].title)


### PR DESCRIPTION
When a partner is created and no title of the type already exists
a models.NewId is used, this causes the same person ingested twice
to be incorrectly treated as separate entities.

Signed-off-by: Robert Smith <robert.smith@unipart.io>