### PR TITLE
[FIX] edi: Dont recalculate values after a failure - may be invalid

### DIFF
--- a/addons/edi/models/edi_document.py
+++ b/addons/edi/models/edi_document.py
@@ -332,7 +332,8 @@ class EdiDocument(models.Model):
         env = self.with_context(tracking_disable=True, recompute=False).env
         try:
             # pylint: disable=broad-except
-            with self.statistics() as stats, self.env.cr.savepoint():
+            with self.statistics() as stats, env.cr.savepoint(),\
+                                             env.clear_upon_failure():
                 self.prepare_date = fields.Datetime.now()
                 DocModel.with_env(env).prepare(self.with_env(env))
                 self.recompute()
@@ -394,7 +395,8 @@ class EdiDocument(models.Model):
         env = self.with_context(tracking_disable=True, recompute=False).env
         try:
             # pylint: disable=broad-except
-            with self.statistics() as stats, self.env.cr.savepoint():
+            with self.statistics() as stats, env.cr.savepoint(),\
+                                             env.clear_upon_failure():
                 DocModel.with_env(env).execute(self.with_env(env))
                 self.recompute()
         except Exception as err:

--- a/addons/edi/models/edi_gateway.py
+++ b/addons/edi/models/edi_gateway.py
@@ -351,10 +351,12 @@ class EdiGateway(models.Model):
                     raise UserError(_("Gateway disabled via configuration "
                                       "option '%s'") % self.safety)
             if conn is not None:
-                with self.env.cr.savepoint():
+                with self.env.cr.savepoint(), self.env.clear_upon_failure():
                     transfer.do_transfer(conn)
             else:
-                with Model.connect(self) as auto_conn, self.env.cr.savepoint():
+                with Model.connect(self) as auto_conn,\
+                        self.env.cr.savepoint(),\
+                        self.env.clear_upon_failure():
                     transfer.do_transfer(auto_conn)
         except Exception as err:
             transfer.raise_issue(_("Transfer failed: %s"), err)

--- a/addons/edi/models/edi_raw_document.py
+++ b/addons/edi/models/edi_raw_document.py
@@ -84,7 +84,7 @@ class EdiRawDocument(models.AbstractModel):
         model = IrModel._get(importer.res_model)
         Model = self.env[model.model]
         try:
-            with self.env.cr.savepoint():
+            with self.env.cr.savepoint(), self.env.clear_upon_failure():
                 res = Model.load(fields, raw[:trial])
                 msgs = res.get('messages')
                 ids = res.get('ids')


### PR DESCRIPTION
Clearing the cache and fields that need to be recalculated after a
failure rollback will prevent further failures from recalculations
or accessing cached objects