### PR TITLE
[IMP] edi: Re-allow deferral of computation during partner record execution

### DIFF
--- a/addons/edi/models/edi_partner_record.py
+++ b/addons/edi/models/edi_partner_record.py
@@ -41,6 +41,8 @@ class EdiPartnerRecord(models.Model):
     BATCH_CREATE = 100
     """Batch size for creating new records"""
 
+    _force_enable_recompute = True
+
     name = fields.Char(string="Internal Reference")
     partner_id = fields.Many2one('res.partner', string="Partner",
                                  required=False, readonly=True, index=True,
@@ -77,7 +79,9 @@ class EdiPartnerRecord(models.Model):
     @api.multi
     def execute(self):
         """Execute records"""
-        super(EdiPartnerRecord, self.with_context(recompute=True)).execute()
+        if self._force_enable_recompute:
+            self = self.with_context(recompute=True)
+        super(EdiPartnerRecord, self).execute()
 
 
 class EdiPartnerTitleRecord(models.Model):


### PR DESCRIPTION
The "recompute=True" context variable was originally introduced in commit
90724af21d181a771833a3dfaf8986bfd0a4e7a9 as a workaround for performance
issues when creating res.partners. In some Odoo configurations where
various parts of res.partner have been disabled, such performance issues
may no longer arise and it may improve performance to defer recomputes again.

User-story: 10070

Signed-off-by: Sean Quah <sean.quah@unipart.io>